### PR TITLE
Fix empty cursor async iterators to not yield undefined

### DIFF
--- a/src/protocol/cursor.ts
+++ b/src/protocol/cursor.ts
@@ -64,7 +64,10 @@ export class CommandCursor<T> {
 
   async *[Symbol.asyncIterator]() {
     while (this.#batches.length > 0 || this.#id !== 0n) {
-      yield await this.next();
+      const value = await this.next();
+      if (value !== undefined) {
+        yield value;
+      }
     }
   }
 

--- a/src/protocol/cursor.ts
+++ b/src/protocol/cursor.ts
@@ -62,7 +62,7 @@ export class CommandCursor<T> {
     return this.#batches.shift();
   }
 
-  async *[Symbol.asyncIterator]() {
+  async *[Symbol.asyncIterator](): AsyncGenerator<T> {
     while (this.#batches.length > 0 || this.#id !== 0n) {
       const value = await this.next();
       if (value !== undefined) {

--- a/tests/curd.test.ts
+++ b/tests/curd.test.ts
@@ -290,3 +290,14 @@ testWithClient("testFindWithSort", async (client) => {
     }),
   );
 });
+
+testWithClient("testFindEmptyAsyncIteration", async (client) => {
+  const db = client.database("test");
+  const users = db.collection<IUser>("mongo_test_users");
+  const cursor = users.find({ nonexistent: 'foo' });
+  const docs = [];
+  for await (const doc of cursor) {
+    docs.push(doc);
+  }
+  assertEquals(docs, []);
+});

--- a/tests/curd.test.ts
+++ b/tests/curd.test.ts
@@ -294,7 +294,7 @@ testWithClient("testFindWithSort", async (client) => {
 testWithClient("testFindEmptyAsyncIteration", async (client) => {
   const db = client.database("test");
   const users = db.collection<IUser>("mongo_test_users");
-  const cursor = users.find({ nonexistent: 'foo' });
+  const cursor = users.find({ nonexistent: "foo" });
   const docs = [];
   for await (const doc of cursor) {
     docs.push(doc);


### PR DESCRIPTION
Empty cursors now yield nothing instead of a single `undefined` value.

Fixes #157