### PR TITLE
Fix: add noCursorTimeout in FindOptions interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export interface FindOptions {
   limit?: number;
   projection?: Document;
   sort?: Document;
+  noCursorTimeout?: boolean;
 }
 
 export interface ListDatabaseInfo {


### PR DESCRIPTION
It's a fix to solve type error as shows in issue #179, adding de property noCursorTimeout in FindOptions interface