### PR TITLE
fix: Use isMaster instead of hello to support older instances

### DIFF
--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -100,10 +100,10 @@ export class Cluster {
     const results = await Promise.all(this.#protocols.map((protocol) => {
       return protocol.commandSingle(
         "admin",
-        { hello: 1 },
+        { isMaster: 1 },
       );
     }));
-    const masterIndex = results.findIndex((result) => result.isWritablePrimary);
+    const masterIndex = results.findIndex((result) => result.isWritablePrimary || result.ismaster);
     if (masterIndex === -1) throw new Error(`Could not find a master node`);
     this.#masterIndex = masterIndex;
   }

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -103,7 +103,9 @@ export class Cluster {
         { isMaster: 1 },
       );
     }));
-    const masterIndex = results.findIndex((result) => result.isWritablePrimary || result.ismaster);
+    const masterIndex = results.findIndex((result) =>
+      result.isWritablePrimary || result.ismaster
+    );
     if (masterIndex === -1) throw new Error(`Could not find a master node`);
     this.#masterIndex = masterIndex;
   }


### PR DESCRIPTION
'hello' is not implemented for older mongos, should use isMaster instead. (https://jira.mongodb.org/browse/SERVER-49986)

Fixes https://github.com/denodrivers/deno_mongo/issues/200#issuecomment-846420784