### PR TITLE
Fix: add a optional generic to collection aggregate type

### DIFF
--- a/src/collection/collection.ts
+++ b/src/collection/collection.ts
@@ -162,8 +162,8 @@ export class Collection<T> {
     return values;
   }
 
-  aggregate(pipeline: Document[], options?: any): AggregateCursor<T> {
-    return new AggregateCursor<T>({
+  aggregate<U = T>(pipeline: Document[], options?: any): AggregateCursor<U> {
+    return new AggregateCursor<U>({
       pipeline,
       protocol: this.#protocol,
       dbName: this.#dbName,


### PR DESCRIPTION
aggregate result type is not always the same as collection type. so an optional generic for this method is required