### PR TITLE
implement dropIndexes

### DIFF
--- a/src/collection/collection.ts
+++ b/src/collection/collection.ts
@@ -6,6 +6,7 @@ import {
   DeleteOptions,
   DistinctOptions,
   Document,
+  DropIndexOptions,
   DropOptions,
   FindOptions,
   InsertOptions,
@@ -182,6 +183,21 @@ export class Collection<T> {
       createIndexes: this.name,
       ...options,
     });
+    return res;
+  }
+
+  async dropIndexes(options: DropIndexOptions) {
+    const res = await this.#protocol.commandSingle<{
+      ok: number;
+      nIndexesWas: number;
+    }>(
+      this.#dbName,
+      {
+        dropIndexes: this.name,
+        ...options,
+      },
+    );
+
     return res;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -497,3 +497,21 @@ export interface CreateIndexOptions {
   /** Optional. A user-provided comment to attach to this command. Once set */
   comment?: Document;
 }
+
+export interface DropIndexOptions {
+  /**
+   * Specifies the indexes to drop.
+   * To drop all but the _id index from the collection, specify "*".
+   * To drop a single index, specify either the index name, the index specification document (unless the index is a text index), or an array of the index name.
+   * To drop a text index, specify the index names instead of the index specification document.
+   * To drop multiple indexes (Available starting in MongoDB 4.2), specify an array of the index names.
+   * See https://docs.mongodb.com/manual/reference/command/dropIndexes/#mongodb-dbcommand-dbcmd.dropIndexes
+   */
+  indexes: string | IndexOptions | string[];
+
+  /** Optional. A document expressing the write concern. Omit to use the default write concern. */
+  writeConcern?: Document;
+
+  /** Optional. A user-provided comment to attach to this command. Once set */
+  comment?: Document;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -507,7 +507,7 @@ export interface DropIndexOptions {
    * To drop multiple indexes (Available starting in MongoDB 4.2), specify an array of the index names.
    * See https://docs.mongodb.com/manual/reference/command/dropIndexes/#mongodb-dbcommand-dbcmd.dropIndexes
    */
-  indexes: string | IndexOptions | string[];
+  index: string | IndexOptions | string[];
 
   /** Optional. A document expressing the write concern. Omit to use the default write concern. */
   writeConcern?: Document;

--- a/tests/cases/04_indexes.ts
+++ b/tests/cases/04_indexes.ts
@@ -35,4 +35,20 @@ export default function indexesTests() {
       ],
     );
   });
+
+  testWithClient("dropndexes", async (client) => {
+    const db = client.database("test");
+    const users = db.collection("mongo_test_users");
+    const res = await users.dropIndexes({
+      indexes: "*",
+    });
+
+    assertEquals(
+      res,
+      {
+        nIndexesWas: 2,
+        ok: 1,
+      },
+    );
+  });
 }

--- a/tests/cases/04_indexes.ts
+++ b/tests/cases/04_indexes.ts
@@ -47,6 +47,10 @@ export default function indexesTests() {
       }],
     });
 
+    await users.dropIndexes({
+      index: "*",
+    });
+
     const indexes = await users.listIndexes().toArray();
 
     assertEquals(

--- a/tests/cases/04_indexes.ts
+++ b/tests/cases/04_indexes.ts
@@ -36,7 +36,7 @@ export default function indexesTests() {
     );
   });
 
-  testWithClient("dropndexes", async (client) => {
+  testWithClient("dropIndexes", async (client) => {
     const db = client.database("test");
     const users = db.collection("mongo_test_users");
     const res = await users.dropIndexes({

--- a/tests/cases/04_indexes.ts
+++ b/tests/cases/04_indexes.ts
@@ -39,16 +39,21 @@ export default function indexesTests() {
   testWithClient("dropIndexes", async (client) => {
     const db = client.database("test");
     const users = db.collection("mongo_test_users");
-    const res = await users.dropIndexes({
-      indexes: "*",
+
+    await users.createIndexes({
+      indexes: [{
+        name: "_name2",
+        key: { name: -1 },
+      }],
     });
 
+    const indexes = await users.listIndexes().toArray();
+
     assertEquals(
-      res,
-      {
-        nIndexesWas: 2,
-        ok: 1,
-      },
+      indexes,
+      [
+        { v: 2, key: { _id: 1 }, name: "_id_", ns: "test.mongo_test_users" },
+      ],
     );
   });
 }


### PR DESCRIPTION
I need `dropIndexes` for my project so I took the opportunity to contribute to the driver.

However I'm not sure about the interface. Currently it's close to the [command](https://docs.mongodb.com/manual/reference/command/dropIndexes/) to be consistent with the current `createIndexes` method, but it's totally different from the interface provided by the nodejs driver where [dropIndex](http://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#dropIndex) can only drop indexes one at a time and where [dropIndexes](http://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#dropIndexes) drops all indexes.

Also I'm not sure about the type of the result of the command, I didn't find the documentation on this subject.