### PR TITLE
Add authentication using authSource

### DIFF
--- a/src/utils/uri.ts
+++ b/src/utils/uri.ts
@@ -123,9 +123,10 @@ export type SrvConnectOptions = Omit<ConnectOptions, "servers"> & {
 export function parseSrvUrl(url: string): SrvConnectOptions {
   const data = parse_url(url);
   const connectOptions: SrvConnectOptions = {
-    db: (data.pathname && data.pathname.length > 1)
+    db: new URLSearchParams(data.search).get("authSource") ?? 
+      ((data.pathname && data.pathname.length > 1)
       ? data.pathname.substring(1)
-      : "admin",
+      : "admin"),
   };
 
   if (data.auth) {
@@ -184,9 +185,10 @@ function parseNormalUrl(url: string): ConnectOptions {
     server.port = server.port || 27017;
   }
 
-  connectOptions.db = (data.pathname && data.pathname.length > 1)
+  connectOptions.db = new URLSearchParams(data.search).get("authSource") ?? 
+    (data.pathname && (data.pathname.length > 1)
     ? data.pathname.substring(1)
-    : "admin";
+    : "admin");
   if (data.auth) {
     connectOptions.credential = <Credential> {
       username: data.auth.user,

--- a/src/utils/uri.ts
+++ b/src/utils/uri.ts
@@ -123,10 +123,10 @@ export type SrvConnectOptions = Omit<ConnectOptions, "servers"> & {
 export function parseSrvUrl(url: string): SrvConnectOptions {
   const data = parse_url(url);
   const connectOptions: SrvConnectOptions = {
-    db: new URLSearchParams(data.search).get("authSource") ?? 
+    db: new URLSearchParams(data.search).get("authSource") ??
       ((data.pathname && data.pathname.length > 1)
-      ? data.pathname.substring(1)
-      : "admin"),
+        ? data.pathname.substring(1)
+        : "admin"),
   };
 
   if (data.auth) {
@@ -185,10 +185,10 @@ function parseNormalUrl(url: string): ConnectOptions {
     server.port = server.port || 27017;
   }
 
-  connectOptions.db = new URLSearchParams(data.search).get("authSource") ?? 
+  connectOptions.db = new URLSearchParams(data.search).get("authSource") ??
     (data.pathname && (data.pathname.length > 1)
-    ? data.pathname.substring(1)
-    : "admin");
+      ? data.pathname.substring(1)
+      : "admin");
   if (data.auth) {
     connectOptions.credential = <Credential> {
       username: data.auth.user,


### PR DESCRIPTION
The [Mongo connection string standard](https://docs.mongodb.com/manual/reference/connection-string/) states that, following the 
`mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]` format, 
> (...) the client will attempt to authenticate the user to the authSource. If authSource is unspecified, the client will attempt to authenticate the user to the defaultauthdb. And if the defaultauthdb is unspecified, to the admin database.

This PR implements auth from the authSource option, with greater priority than defaultauthdb, as stated above.