### PR TITLE
Chore: assorted code clean-up and dependency bumps

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,14 +1,14 @@
 export * as Bson from "./bson/mod.ts";
-export { createHash } from "https://deno.land/std@0.102.0/hash/mod.ts";
-export { pbkdf2Sync } from "https://deno.land/std@0.102.0/node/_crypto/pbkdf2.ts";
-export { HmacSha1 } from "https://deno.land/std@0.102.0/hash/sha1.ts";
-export { HmacSha256 } from "https://deno.land/std@0.102.0/hash/sha256.ts";
+export { createHash } from "https://deno.land/std@0.105.0/hash/mod.ts";
+export { pbkdf2Sync } from "https://deno.land/std@0.105.0/node/_crypto/pbkdf2.ts";
+export { HmacSha1 } from "https://deno.land/std@0.105.0/hash/sha1.ts";
+export { HmacSha256 } from "https://deno.land/std@0.105.0/hash/sha256.ts";
 export * from "https://deno.land/x/bytes_formater@v1.4.0/mod.ts";
-export { BufReader, writeAll } from "https://deno.land/std@0.102.0/io/mod.ts";
-export { deferred } from "https://deno.land/std@0.102.0/async/deferred.ts";
-export type { Deferred } from "https://deno.land/std@0.102.0/async/deferred.ts";
-export * as b64 from "https://deno.land/std@0.102.0/encoding/base64.ts";
+export { BufReader, writeAll } from "https://deno.land/std@0.105.0/io/mod.ts";
+export { deferred } from "https://deno.land/std@0.105.0/async/deferred.ts";
+export type { Deferred } from "https://deno.land/std@0.105.0/async/deferred.ts";
+export * as b64 from "https://deno.land/std@0.105.0/encoding/base64.ts";
 export {
   assert,
   assertEquals,
-} from "https://deno.land/std@0.102.0/testing/asserts.ts";
+} from "https://deno.land/std@0.105.0/testing/asserts.ts";

--- a/src/client.ts
+++ b/src/client.ts
@@ -29,15 +29,12 @@ export class MongoClient {
     return this.database((options as ConnectOptions).db);
   }
 
-  async listDatabases(options?: {
+  async listDatabases(options: {
     filter?: Document;
     nameOnly?: boolean;
     authorizedCollections?: boolean;
     comment?: Document;
-  }): Promise<ListDatabaseInfo[]> {
-    if (!options) {
-      options = {};
-    }
+  } = {}): Promise<ListDatabaseInfo[]> {
     assert(this.#cluster);
     const { databases } = await this.#cluster.protocol.commandSingle("admin", {
       listDatabases: 1,

--- a/src/database.ts
+++ b/src/database.ts
@@ -33,15 +33,12 @@ export class Database {
     return new Collection(this.#cluster.protocol, this.name, name);
   }
 
-  listCollections(options?: {
+  listCollections(options: {
     filter?: Document;
     nameOnly?: boolean;
     authorizedCollections?: boolean;
     comment?: Document;
-  }): CommandCursor<ListCollectionsResult> {
-    if (!options) {
-      options = {};
-    }
+  } = {}): CommandCursor<ListCollectionsResult> {
     return new CommandCursor<ListCollectionsResult>(
       this.#cluster.protocol,
       async () => {
@@ -61,11 +58,11 @@ export class Database {
     );
   }
 
-  async listCollectionNames(options?: {
+  async listCollectionNames(options: {
     filter?: Document;
     authorizedCollections?: boolean;
     comment?: Document;
-  }): Promise<string[]> {
+  } = {}): Promise<string[]> {
     const cursor = this.listCollections({
       ...options,
       nameOnly: true,
@@ -96,10 +93,10 @@ export class Database {
     });
   }
 
-  async dropUser(username: string, options?: {
+  async dropUser(username: string, options: {
     writeConcern?: Document;
     comment?: Document;
-  }) {
+  } = {}) {
     await this.#cluster.protocol.commandSingle(this.name, {
       dropUser: username,
       writeConcern: options?.writeConcern,

--- a/src/database.ts
+++ b/src/database.ts
@@ -70,7 +70,7 @@ export class Database {
     });
     const names: string[] = [];
     for await (const item of cursor) {
-      names.push(item!.name);
+      names.push(item.name);
     }
     return names;
   }

--- a/tests/cases/01_auth.ts
+++ b/tests/cases/01_auth.ts
@@ -96,7 +96,7 @@ export default function authTests() {
       );
       assertEquals(
         saltedPassword,
-        [
+        Uint8Array.from([
           72,
           84,
           156,
@@ -117,7 +117,7 @@ export default function authTests() {
           110,
           78,
           230,
-        ],
+        ]),
       );
     },
   });

--- a/tests/test.deps.ts
+++ b/tests/test.deps.ts
@@ -1,7 +1,7 @@
-export { exists } from "https://deno.land/std@0.102.0/fs/mod.ts";
+export { exists } from "https://deno.land/std@0.105.0/fs/mod.ts";
 export {
   assert,
   assertEquals,
   assertThrows,
   assertThrowsAsync,
-} from "https://deno.land/std@0.102.0/testing/asserts.ts";
+} from "https://deno.land/std@0.105.0/testing/asserts.ts";


### PR DESCRIPTION
This PR removes the manual defaulting of the `options` parameter in various functions.

```typescript
// Previously, functions that took in an `options` object
// manually used `if` conditions for defaulting.
function someFunc(options?: Options) {
  if (!options) options = {};
  // ...
}
```

Now, we use ES6 default parameters.

```typescript
// Hooray!
function someFunc(options: Options = {}) {
  // ...
}
```

I have also continued some work on my previous PR (#218) by removing the usage of `return await` in the `Cluster` class.

Finally, I also bumped up the `std` dependencies to `0.105.0` (the latest as of writing). One of the tests was broken as a result of the upgrade, but the fix was trivial. The test case in question asserted a value (`saltedPassword`) to be of type `number[]` rather than to be of type `Uint8Array`, which the newer version of `assertEquals` no longer allowed. Thus, I simply used the `Uint8Array.from` wrapper function to fix the assertion failure.

Overall, there should be no changes in behavior. Thanks!