### PR TITLE
feat: cache build info in connection

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,10 @@
 import { Database } from "./database.ts";
-import { ConnectOptions, Document, ListDatabaseInfo } from "./types.ts";
+import {
+  BuildInfo,
+  ConnectOptions,
+  Document,
+  ListDatabaseInfo,
+} from "./types.ts";
 import { parse } from "./utils/uri.ts";
 import { MongoDriverError } from "./error.ts";
 import { Cluster } from "./cluster.ts";
@@ -8,6 +13,11 @@ import { assert } from "../deps.ts";
 export class MongoClient {
   #cluster?: Cluster;
   #defaultDbName = "admin";
+  #buildInfo?: BuildInfo;
+
+  get buildInfo() {
+    return this.#buildInfo;
+  }
 
   async connect(
     options: ConnectOptions | string,
@@ -22,7 +32,11 @@ export class MongoClient {
       await cluster.connect();
       await cluster.authenticate();
       await cluster.updateMaster();
+
       this.#cluster = cluster;
+      this.#buildInfo = await this.runCommand(this.#defaultDbName, {
+        buildInfo: 1,
+      });
     } catch (e) {
       throw new MongoDriverError(`Connection failed: ${e.message || e}`);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -617,3 +617,73 @@ export interface DropIndexOptions {
   /** Optional. A user-provided comment to attach to this command. Once set */
   comment?: Document;
 }
+
+/** The document returned by the buildInfo command. */
+export interface BuildInfo {
+  /**
+   * A string that conveys version information about the `mongod` instance.
+   * If you need to present version information to a human, this field is preferable to `versionArray`.
+   *
+   * This string will take the format `<major>.<minor>.<patch>` in the case of a release,
+   * but development builds may contain additional information.
+   */
+  version: string;
+
+  /** The commit identifier that identifies the state of the code used to build the mongod. */
+  gitVersion: string;
+
+  /**
+   * @deprecated since 3.2
+   * `buildInfo.sysInfo` no longer contains useful information.
+   */
+  sysInfo: string;
+
+  loaderFlags: string;
+
+  compilerFlags: string;
+
+  /**
+   * The memory allocator that mongod uses. By default this is tcmalloc.
+   */
+  allocator: string;
+
+  /**
+   * An array that conveys version information about the mongod instance.
+   * See version for a more readable version of this string.
+   */
+  versionArray: number[];
+
+  /**
+   * An embedded document describing the version of the TLS/SSL library that mongod
+   * was built with and is currently using.
+   */
+  openssl: Document;
+
+  /**
+   * A string that reports the JavaScript engine used in the mongod instance.
+   * By default, this is mozjs after version 3.2, and previously V8.
+   */
+  javascriptEngine: string;
+
+  /**
+   * A number that reflects the target processor architecture of the mongod binary.
+   */
+  bits: number;
+
+  /**
+   * A boolean. true when built with debugging options.
+   */
+  debug: boolean;
+
+  /**
+   * A number that reports the Maximum BSON Document Size.
+   */
+  maxBsonObjectSize: number;
+
+  /**
+   * A list of storage engines available to the mongod server.
+   */
+  storageEngines: string[];
+
+  ok: number;
+}


### PR DESCRIPTION
Sometimes we need to access build info, such as version information to adjust the behavior of the driver.