### PR TITLE
refactor: remove use of Deno.close

### DIFF
--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -119,7 +119,7 @@ export class Cluster {
   close() {
     for (const conn of this.#connections) {
       try {
-        Deno.close(conn.rid);
+        conn.close();
       } catch (error) {
         console.error(`Error closing connection: ${error}`);
       }


### PR DESCRIPTION
It is better practice to use the `.close()` method than the `Deno.close` API. This makes the code also work in Deno Deploy conincidentally.﻿
