### PR TITLE
Update cluster.ts, certFile is deprecated in Deno. Now is caCerts.

### DIFF
--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -33,7 +33,9 @@ export class Cluster {
 
     if (!options.tls) return Deno.connect(denoConnectOps);
 
-    if (options.certFile) denoConnectOps.caCerts = [Deno.readTextFileSync(options.certFile)];
+    if (options.certFile) {
+      denoConnectOps.caCerts = [Deno.readTextFileSync(options.certFile)];
+    }
 
     if (options.keyFile) {
       //TODO: need something like const key = decrypt(options.keyFile) ...

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -33,7 +33,7 @@ export class Cluster {
 
     if (!options.tls) return Deno.connect(denoConnectOps);
 
-    if (options.certFile) denoConnectOps.certFile = options.certFile;
+    if (options.certFile) denoConnectOps.caCerts = [Deno.readTextFileSync(options.certFile)];
 
     if (options.keyFile) {
       //TODO: need something like const key = decrypt(options.keyFile) ...


### PR DESCRIPTION
certFile is deprecated in Deno. Now is caCerts.