### PR TITLE
chore: `assertThrowsAsync` is deprecated

### DIFF
--- a/tests/cases/03_curd.ts
+++ b/tests/cases/03_curd.ts
@@ -1,6 +1,6 @@
 import { MongoInvalidArgumentError } from "../../src/error.ts";
 import { testWithClient, testWithTestDBClient } from "../common.ts";
-import { assert, assertEquals, assertThrowsAsync } from "../test.deps.ts";
+import { assert, assertEquals, assertRejects } from "../test.deps.ts";
 
 interface IUser {
   username?: string;
@@ -81,7 +81,7 @@ export default function curdTests() {
       username: "user1",
     });
 
-    await assertThrowsAsync(
+    await assertRejects(
       () =>
         users.insertOne({
           _id: "aaaaaaaaaaaaaaaaaaaaaaaa",

--- a/tests/cases/05_srv.ts
+++ b/tests/cases/05_srv.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrowsAsync } from "../test.deps.ts";
+import { assertEquals, assertRejects } from "../test.deps.ts";
 import { Srv } from "../../src/utils/srv.ts";
 
 function mockResolver(
@@ -18,7 +18,7 @@ export default function srvTests() {
   Deno.test({
     name: "SRV: it throws an error if url doesn't have subdomain",
     fn() {
-      assertThrowsAsync(
+      assertRejects(
         () => new Srv().resolve("foo.bar"),
         Error,
         "Expected url in format 'host.domain.tld', received foo.bar",
@@ -30,7 +30,7 @@ export default function srvTests() {
     name:
       "SRV: it throws an error if SRV resolution doesn't return any SRV records",
     fn() {
-      assertThrowsAsync(
+      assertRejects(
         () => new Srv(mockResolver()).resolve("mongohost.mongodomain.com"),
         Error,
         "Expected at least one SRV record, received 0 for url mongohost.mongodomain.com",
@@ -41,7 +41,7 @@ export default function srvTests() {
   Deno.test({
     name: "SRV: it throws an error if TXT resolution returns no records",
     fn() {
-      assertThrowsAsync(
+      assertRejects(
         () =>
           new Srv(mockResolver([{ target: "mongohost1.mongodomain.com" }]))
             .resolve("mongohost.mongodomain.com"),
@@ -55,7 +55,7 @@ export default function srvTests() {
     name:
       "SRV: it throws an error if TXT resolution returns more than one record",
     fn() {
-      assertThrowsAsync(
+      assertRejects(
         () =>
           new Srv(
             mockResolver(
@@ -73,7 +73,7 @@ export default function srvTests() {
   Deno.test({
     name: "SRV: it throws an error if TXT record contains illegal options",
     fn() {
-      assertThrowsAsync(
+      assertRejects(
         () =>
           new Srv(
             mockResolver(

--- a/tests/test.deps.ts
+++ b/tests/test.deps.ts
@@ -2,6 +2,6 @@ export {
   assert,
   assertEquals,
   assertThrows,
-  assertThrowsAsync,
+  assertRejects,
 } from "https://deno.land/std@0.117.0/testing/asserts.ts";
 export * as semver from "https://deno.land/x/semver@v1.4.0/mod.ts";

--- a/tests/test.deps.ts
+++ b/tests/test.deps.ts
@@ -1,7 +1,7 @@
 export {
   assert,
   assertEquals,
-  assertThrows,
   assertRejects,
+  assertThrows,
 } from "https://deno.land/std@0.117.0/testing/asserts.ts";
 export * as semver from "https://deno.land/x/semver@v1.4.0/mod.ts";


### PR DESCRIPTION
Ref: https://deno.land/std@0.117.0/testing/README.md