### PR TITLE
fix: nin type when used on arrays

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -626,7 +626,7 @@ interface FilterOperators<TValue> extends Document {
   $lt?: TValue;
   $lte?: TValue;
   $ne?: TValue;
-  $nin?: Array<TValue>;
+  $nin?: TValue extends (infer T)[] ? T[] : Array<TValue>;
   $not?: FilterOperators<TValue>;
   $exists?: boolean;
   $expr?: Document;


### PR DESCRIPTION
Attempt to fix issue #314 

I change the type info for $nin. When it's used on arrays, the type should be an array of the "array item"