### PR TITLE
Fix: auth db defaults

### DIFF
--- a/src/utils/uri.ts
+++ b/src/utils/uri.ts
@@ -146,7 +146,7 @@ export function parseSrvUrl(url: string): SrvConnectOptions {
     connectOptions.credential = <Credential> {
       username: data.auth.user,
       password: data.auth.password,
-      db: authSource ?? defaultAuthDb ?? "admin",
+      db: authSource ?? "admin",
       mechanism: data.search.authMechanism || "SCRAM-SHA-256",
     };
   }
@@ -212,7 +212,7 @@ function parseNormalUrl(url: string): ConnectOptions {
     connectOptions.credential = <Credential> {
       username: data.auth.user,
       password: data.auth.password,
-      db: authSource ?? defaultAuthDb ?? "admin",
+      db: authSource ?? "admin",
       mechanism: data.search.authMechanism || "SCRAM-SHA-256",
     };
   }

--- a/tests/cases/00_uri.ts
+++ b/tests/cases/00_uri.ts
@@ -200,6 +200,7 @@ export default function uriTests() {
         assertEquals(options.db, "someDatabaseName");
         assertEquals(options.credential?.username, "someUser");
         assertEquals(options.credential?.password, "somePassword");
+        assertEquals(options.credential?.db, "admin");
         assertEquals(options.retryWrites, true);
         // deno-lint-ignore no-explicit-any
         assertEquals((options as any)["servers"], undefined);

--- a/tests/cases/00_uri.ts
+++ b/tests/cases/00_uri.ts
@@ -68,7 +68,7 @@ export default function uriTests() {
       assertEquals(options.servers[0].host, "localhost");
       assertEquals(options.credential!.username, "fred");
       assertEquals(options.credential!.password, "foobar");
-      assertEquals(options.credential!.db, "baz");
+      assertEquals(options.credential!.db, "admin");
     },
   });
 
@@ -81,7 +81,7 @@ export default function uriTests() {
       assertEquals(options.servers[0].host, "localhost");
       assertEquals(options.credential!.username, "fred");
       assertEquals(options.credential!.password, "foo bar");
-      assertEquals(options.credential!.db, "baz");
+      assertEquals(options.credential!.db, "admin");
     },
   });
 
@@ -121,7 +121,7 @@ export default function uriTests() {
       assertEquals(options.servers[0].domainSocket, "/tmp/mongodb-27017.sock");
       assertEquals(options.credential!.username, "fred");
       assertEquals(options.credential!.password, "foo");
-      assertEquals(options.credential!.db, "somedb");
+      assertEquals(options.credential!.db, "admin");
       assertEquals(options.db, "somedb");
     },
   });
@@ -137,7 +137,7 @@ export default function uriTests() {
       assertEquals(options.servers[0].domainSocket, "/tmp/mongodb-27017.sock");
       assertEquals(options.credential!.username, "fred");
       assertEquals(options.credential!.password, "foo");
-      assertEquals(options.credential!.db, "somedb");
+      assertEquals(options.credential!.db, "admin");
       assertEquals(options.db, "somedb");
       assertEquals(options.safe, true);
     },
@@ -157,7 +157,7 @@ export default function uriTests() {
       assertEquals(options.servers[1].port, 28101);
       assertEquals(options.credential!.username, "fred");
       assertEquals(options.credential!.password, "foobar");
-      assertEquals(options.credential!.db, "baz");
+      assertEquals(options.credential!.db, "admin");
     },
   });
   // TODO: add more tests (https://github.com/mongodb/node-mongodb-native/blob/3.6/test/functional/url_parser.test.js)

--- a/tests/cases/01_auth.ts
+++ b/tests/cases/01_auth.ts
@@ -133,7 +133,7 @@ export default function authTests() {
     const password = "y3mq3mpZ3J6PGfgg";
     const client = new MongoClient();
     await client.connect(
-      `mongodb://${username}:${password}@${hostname}:27017/test`,
+      `mongodb://${username}:${password}@${hostname}:27017/test?authSource=test`,
     );
     const names = await client.listDatabases();
     assert(names instanceof Array);
@@ -146,7 +146,7 @@ export default function authTests() {
     const password = "Qa6WkQSuXF425sWZ";
     const client = new MongoClient();
     await client.connect(
-      `mongodb://${username}:${password}@${hostname}:27017/test`,
+      `mongodb://${username}:${password}@${hostname}:27017/test?authSource=test`,
     );
     const names = await client.listDatabases();
     assert(names instanceof Array);


### PR DESCRIPTION
Current Behaviour:
`authSource` is changed when database name is passed in the connection string. The issue is in setting defaults, same connection string worked on nodejs official driver but didn't work with deno_mongo.

After Merge:
`authSource` will be changed only if `authSource` will be passed in the connection string, otherwise it will keep the default `admin` db as authSource



Related issue:
https://github.com/denodrivers/deno_mongo/issues/319

