### PR TITLE
fix: default `noCursorTimeout` to `false`

### DIFF
--- a/src/collection/commands/find.ts
+++ b/src/collection/commands/find.ts
@@ -18,7 +18,7 @@ export class FindCursor<T> extends CommandCursor<T> {
       find: collectionName,
       filter,
       batchSize: 1,
-      noCursorTimeout: true,
+      noCursorTimeout: false,
       ...options,
     });
     return {


### PR DESCRIPTION
This is what the Node mongodb driver does as far as I can tell. This is required for lower tier MongoDB Atlas instances.