### PR TITLE
Feature/ssl param

### DIFF
--- a/src/utils/uri.ts
+++ b/src/utils/uri.ts
@@ -143,7 +143,7 @@ export function parseSrvUrl(url: string): SrvConnectOptions {
   };
 
   if (data.auth) {
-    connectOptions.credential = <Credential>{
+    connectOptions.credential = <Credential> {
       username: data.auth.user,
       password: data.auth.password,
       db: authSource ?? defaultAuthDb ?? "admin",
@@ -212,7 +212,7 @@ function parseNormalUrl(url: string): ConnectOptions {
   }
 
   if (data.auth) {
-    connectOptions.credential = <Credential>{
+    connectOptions.credential = <Credential> {
       username: data.auth.user,
       password: data.auth.password,
       db: authSource ?? defaultAuthDb ?? "admin",

--- a/src/utils/uri.ts
+++ b/src/utils/uri.ts
@@ -143,7 +143,7 @@ export function parseSrvUrl(url: string): SrvConnectOptions {
   };
 
   if (data.auth) {
-    connectOptions.credential = <Credential> {
+    connectOptions.credential = <Credential>{
       username: data.auth.user,
       password: data.auth.password,
       db: authSource ?? defaultAuthDb ?? "admin",
@@ -157,6 +157,9 @@ export function parseSrvUrl(url: string): SrvConnectOptions {
 
   if (data.search.appname) {
     connectOptions.appname = data.search.appname;
+  }
+  if (data.search.ssl) {
+    connectOptions.tls = data.search.ssl === "true";
   }
   if (data.search.tls) {
     connectOptions.tls = data.search.tls === "true";
@@ -209,7 +212,7 @@ function parseNormalUrl(url: string): ConnectOptions {
   }
 
   if (data.auth) {
-    connectOptions.credential = <Credential> {
+    connectOptions.credential = <Credential>{
       username: data.auth.user,
       password: data.auth.password,
       db: authSource ?? defaultAuthDb ?? "admin",
@@ -221,6 +224,9 @@ function parseNormalUrl(url: string): ConnectOptions {
     : [];
   if (data.search.appname) {
     connectOptions.appname = data.search.appname;
+  }
+  if (data.search.ssl) {
+    connectOptions.tls = data.search.ssl === "true";
   }
   if (data.search.tls) {
     connectOptions.tls = data.search.tls === "true";
@@ -236,6 +242,9 @@ function parseNormalUrl(url: string): ConnectOptions {
   }
   if (data.search.safe) {
     connectOptions.safe = data.search.safe === "true";
+  }
+  if (data.search.retryWrites) {
+    connectOptions.retryWrites = data.search.retryWrites === "true";
   }
   return connectOptions;
 }

--- a/tests/cases/00_uri.ts
+++ b/tests/cases/00_uri.ts
@@ -36,6 +36,26 @@ export default function uriTests() {
   });
 
   Deno.test({
+    name: 'should parse ?ssl=true',
+    async fn() {
+      const options = await parse(
+        "mongodb://localhost:27017/test?ssl=true",
+      )
+      assertEquals(options.tls, true)
+    }
+  });
+
+  Deno.test({
+    name: 'should parse ?ssl=true',
+    async fn() {
+      const options = await parse(
+        "mongodb+srv://localhost:27017/test?ssl=true",
+      )
+      assertEquals(options.tls, true)
+    }
+  });
+
+  Deno.test({
     name:
       "should correctly parse mongodb://localhost/?safe=true&readPreference=secondary",
     async fn() {

--- a/tests/cases/00_uri.ts
+++ b/tests/cases/00_uri.ts
@@ -36,23 +36,23 @@ export default function uriTests() {
   });
 
   Deno.test({
-    name: 'should parse ?ssl=true',
+    name: "should parse ?ssl=true",
     async fn() {
       const options = await parse(
         "mongodb://localhost:27017/test?ssl=true",
-      )
-      assertEquals(options.tls, true)
-    }
+      );
+      assertEquals(options.tls, true);
+    },
   });
 
   Deno.test({
-    name: 'should parse ?ssl=true',
+    name: "should parse ?ssl=true",
     async fn() {
       const options = await parse(
         "mongodb+srv://localhost:27017/test?ssl=true",
-      )
-      assertEquals(options.tls, true)
-    }
+      );
+      assertEquals(options.tls, true);
+    },
   });
 
   Deno.test({


### PR DESCRIPTION
When you create an Azure cosmos db it gives you a connection string like this:

```
mongodb://example:<redacted>@example.mongo.cosmos.azure.com:10255/?ssl=true&replicaSet=globaldb&retrywrites=false&maxIdleTimeMS=120000&appName=@example@
```

However when you try to use this connection string to actually connect it basically hangs indefinitely. After some debugging I figured out that the connection string parsing is simply not handling the `ssl=true` parameter. Simply setting `tls = true` in this case allows deno_mongo to successfully connect to azure cosmosdb.