### PR TITLE
fix: how to connect to local MongoDB instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import {
 const client = new MongoClient();
 
 // Connecting to a Local Database
-await client.connect("mongodb://localhost:27017");
+await client.connect("mongodb://127.0.0.1:27017");
 
 // Connecting to a Mongo Atlas Database
 await client.connect({


### PR DESCRIPTION
The current step on how to connect to a local MongoDB instance can cause the error detailed in the following issue:
https://github.com/denodrivers/deno_mongo/issues/170

The proposed changes aim to fix that by replacing the "mongodb://localhost:27017" with "mongodb://127.0.0.1:27017".

This fixed was submitted by @michaeldesu in the issue linked above.