### PR TITLE
feat: support `database.createCollection`

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -1,6 +1,6 @@
 import { Collection } from "./collection/mod.ts";
 import { CommandCursor } from "./protocol/mod.ts";
-import { CreateUserOptions } from "./types.ts";
+import { CreateCollectionOptions, CreateUserOptions } from "./types.ts";
 import { Cluster } from "./cluster.ts";
 import { Document } from "../deps.ts";
 
@@ -73,6 +73,23 @@ export class Database {
       names.push(item.name);
     }
     return names;
+  }
+
+  /**
+   * `createCollection` executes a create command to create a new collection with the specified name and options.
+   *
+   * https://www.mongodb.com/docs/manual/reference/command/create/#mongodb-dbcommand-dbcmd.create
+   */
+  async createCollection<T>(
+    name: string,
+    options?: CreateCollectionOptions,
+  ): Promise<Collection<T>> {
+    await this.#cluster.protocol.commandSingle(
+      this.name,
+      { create: name, ...options },
+    );
+
+    return this.collection<T>(name);
   }
 
   createUser(

--- a/src/types.ts
+++ b/src/types.ts
@@ -880,3 +880,32 @@ export const enum ReadPreference {
   SecondaryPreferred = "secondaryPreferred",
   Nearest = "nearest",
 }
+
+export type TimeSeriesGranularity = "seconds" | "minutes" | "hours";
+export type ValidationLevel = "off" | "strict" | "moderate";
+export type ValidationAction = "error" | "warn";
+
+/**
+ * https://www.mongodb.com/docs/manual/reference/method/db.createCollection/
+ */
+export interface CreateCollectionOptions {
+  capped?: boolean;
+  timeseries?: {
+    timeField: string;
+    metaField?: string;
+    granularity?: TimeSeriesGranularity;
+  };
+  expireAfterSeconds?: number;
+  autoIndex?: boolean;
+  size?: number;
+  max?: number;
+  storageEngine?: Document;
+  validator?: Document;
+  validationLevel?: ValidationLevel;
+  validationAction?: ValidationAction;
+  indexOptionDefaults?: Document;
+  viewOn?: string;
+  pipeline?: Document[];
+  collation?: Document;
+  writeConcern?: Document;
+}


### PR DESCRIPTION
## Description
This will simply add support for `createCollection` on `database` which resolves #352 

## Tests
Since `createCollection` is just a special case of `runCommand`, I added some simple test cases only. 

## Possible issues in the future
- If some kind of validation is added in the future, it is likely that the query will be validated first at the driver level.
- `CreateCollectionOptions` can be expressed in more detail regarding options for capped collection, time series collection, validators and so on.
